### PR TITLE
feat: use tuples for async return types

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,15 +102,15 @@ In Luau, for full type-checking in your editor, you will need to define a separa
 
 - `ServerToClient<Args...>`: A remote event that is fired by the server and processed by the client.
 
-- `ClientToServerAsync<Result, (Args...)>`: A remote function that is invoked by the client and processed by the server.
+- `ServerAsync<Args..., Returns...>`: A remote function that is invoked by the client and processed by the server.
 
-- ~~`ServerToClientAsync<Result, (Args...)>`~~: A remote function that is invoked by the server and processed by the client. Not recommended, as requesting values from the client is unsafe.
+- ~~`ClientAsync<Args..., Returns...>`~~: A remote function that is invoked by the server and processed by the client. Not recommended, as requesting values from the client is unsafe.
 
 ```lua
 type Remotes = {
 	client: Remo.ServerToClient<number>,
 	server: Remo.ClientToServer<number>,
-	serverAsync: Remo.ClientToServerAsync<string, (number)>,
+	serverAsync: Remo.ServerAsync<(number), (string)>,
 	namespace: {
 		client: Remo.ServerToClient<number>,
 		server: Remo.ClientToServer<number>,

--- a/src/Promise.lua
+++ b/src/Promise.lua
@@ -1,4 +1,3 @@
---!nonstrict
 local ReplicatedStorage = game:GetService("ReplicatedStorage")
 
 local include = script:FindFirstAncestor("rbxts_include")
@@ -54,22 +53,22 @@ export type _Promise = {
 	now: (self: _Promise, rejectionValue: unknown) -> _Promise,
 }
 
-export type Promise<T = any> = {
-	timeout: (self: Promise<T>, seconds: number, rejectionValue: unknown) -> Promise<T>,
-	getStatus: (self: Promise<T>) -> PromiseStatus,
-	andThen: (self: Promise<T>, successHandler: (T) -> (), failureHandler: ((...any) -> ())?) -> _Promise,
-	catch: (self: Promise<T>, failureHandler: (any) -> ()) -> Promise<T>,
-	tap: (self: Promise<T>, successHandler: (T) -> ()) -> Promise<T>,
-	andThenCall: <U...>(self: Promise<T>, successHandler: (U...) -> (), U...) -> Promise<T>,
-	andThenReturn: (self: Promise<T>, value: any) -> _Promise,
-	cancel: (self: Promise<T>) -> (),
-	finally: (self: Promise<T>, callback: (status: PromiseStatus) -> ()) -> _Promise,
-	finallyCall: <U...>(self: Promise<T>, callback: (U...) -> (), U...) -> _Promise,
-	finallyReturn: (self: Promise<T>, value: any) -> _Promise,
-	awaitStatus: (self: Promise<T>) -> (PromiseStatus, T),
-	await: (self: Promise<T>) -> (boolean, T | unknown),
-	expect: (self: Promise<T>) -> T,
-	now: (self: Promise<T>, rejectionValue: unknown) -> Promise<T>,
+export type Promise<T... = ...any> = {
+	timeout: (self: Promise<T...>, seconds: number, rejectionValue: unknown) -> Promise<T...>,
+	getStatus: (self: Promise<T...>) -> PromiseStatus,
+	andThen: (self: Promise<T...>, successHandler: (T...) -> (), failureHandler: ((...any) -> ())?) -> _Promise,
+	catch: (self: Promise<T...>, failureHandler: (any) -> ()) -> Promise<T...>,
+	tap: (self: Promise<T...>, successHandler: (T...) -> ()) -> Promise<T...>,
+	andThenCall: <U...>(self: Promise<T...>, successHandler: (U...) -> (), U...) -> Promise<T...>,
+	andThenReturn: (self: Promise<T...>, value: any) -> _Promise,
+	cancel: (self: Promise<T...>) -> (),
+	finally: (self: Promise<T...>, callback: (status: PromiseStatus) -> ()) -> _Promise,
+	finallyCall: <U...>(self: Promise<T...>, callback: (U...) -> (), U...) -> _Promise,
+	finallyReturn: (self: Promise<T...>, value: any) -> _Promise,
+	awaitStatus: (self: Promise<T...>) -> (PromiseStatus, T...),
+	await: (self: Promise<T...>) -> (boolean, T...),
+	expect: (self: Promise<T...>) -> T...,
+	now: (self: Promise<T...>, rejectionValue: unknown) -> Promise<T...>,
 }
 
 if include and include:FindFirstChild("Promise") then

--- a/src/client/createAsyncRemote.lua
+++ b/src/client/createAsyncRemote.lua
@@ -41,7 +41,7 @@ local function createAsyncRemote(name: string, builder: types.RemoteBuilder): ty
 		end
 	end
 
-	local asyncRemoteNotCallable: types.AsyncRemoteNotCallable = {
+	local api: types.AsyncRemoteApi = {
 		name = name,
 		type = "function" :: "function",
 		onRequest = onRequest,
@@ -49,7 +49,7 @@ local function createAsyncRemote(name: string, builder: types.RemoteBuilder): ty
 		destroy = destroy,
 	}
 
-	local asyncRemote = setmetatable(asyncRemoteNotCallable, {
+	local asyncRemote = setmetatable(api, {
 		__call = request,
 	}) :: types.AsyncRemote
 

--- a/src/createRemotes.spec.lua
+++ b/src/createRemotes.spec.lua
@@ -9,10 +9,10 @@ return function()
 
 	local remotes: types.Remotes<{
 		event: types.ClientToServer<string, number>,
-		callback: types.ClientToServerAsync<string, (string, number)>,
+		callback: types.ServerAsync<(string, number), (string, nil)>,
 		namespace: {
 			event: types.ClientToServer<string, number>,
-			callback: types.ClientToServerAsync<string, (string, number)>,
+			callback: types.ServerAsync<(string, number), (string, nil)>,
 		},
 	}>
 

--- a/src/createRemotes.spec.lua
+++ b/src/createRemotes.spec.lua
@@ -7,6 +7,7 @@ return function()
 	local builder = require(script.Parent.builder)
 	local mockRemotes = require(script.Parent.utils.mockRemotes)
 
+	-- TODO: remove 'nil' from type packs
 	local remotes: types.Remotes<{
 		event: types.ClientToServer<string, number>,
 		callback: types.ServerAsync<(string, number), (string, nil)>,

--- a/src/init.lua
+++ b/src/init.lua
@@ -1,3 +1,4 @@
+local Promise = require(script.Promise)
 local types = require(script.types)
 local createRemotes = require(script.createRemotes)
 local builder = require(script.builder)
@@ -5,12 +6,10 @@ local getSender = require(script.getSender)
 local loggerMiddleware = require(script.middleware.loggerMiddleware)
 local throttleMiddleware = require(script.middleware.throttleMiddleware)
 
-export type Promise<T> = types.Promise<T>
-export type PromiseConstructor = types.PromiseConstructor
-export type Validator = types.Validator
+export type Promise<T> = Promise.Promise<T>
+export type PromiseConstructor = Promise.PromiseConstructor
 
 export type Middleware = types.Middleware
-export type MiddlewareContext = types.MiddlewareContext
 
 export type RemoteBuilder = types.RemoteBuilder
 export type RemoteBuilderMetadata = types.RemoteBuilderMetadata
@@ -24,9 +23,15 @@ export type Remote<Args... = ...any> = types.Remote<Args...>
 export type ClientToServer<Args... = ...any> = types.ClientToServer<Args...>
 export type ServerToClient<Args... = ...any> = types.ServerToClient<Args...>
 
-export type AsyncRemote<Returns = any, Args... = ...any> = types.AsyncRemote<Returns, Args...>
-export type ClientToServerAsync<Returns = any, Args... = ...any> = types.ClientToServerAsync<Returns, Args...>
-export type ServerToClientAsync<Returns = any, Args... = ...any> = types.ServerToClientAsync<Returns, Args...>
+export type AsyncRemote<Args... = ...any, Returns... = ...any> = types.AsyncRemote<Args..., Returns...>
+export type ServerAsync<Args... = ...any, Returns... = ...any> = types.ServerAsync<Args..., Returns...>
+export type ClientAsync<Args... = ...any, Returns... = ...any> = types.ClientAsync<Args..., Returns...>
+
+--- @deprecated 1.2, use `ServerAsync` instead.
+export type ClientToServerAsync<Returns = any, Args... = ...any> = types.ServerAsync<Args..., (Returns, nil)>
+
+--- @deprecated 1.2, use `ClientAsync` instead.
+export type ServerToClientAsync<Returns = any, Args... = ...any> = types.ClientAsync<Args..., (Returns, nil)>
 
 return {
 	remote = builder.remote,

--- a/src/init.lua
+++ b/src/init.lua
@@ -27,9 +27,9 @@ export type AsyncRemote<Args... = ...any, Returns... = ...any> = types.AsyncRemo
 export type ServerAsync<Args... = ...any, Returns... = ...any> = types.ServerAsync<Args..., Returns...>
 export type ClientAsync<Args... = ...any, Returns... = ...any> = types.ClientAsync<Args..., Returns...>
 
+--- TODO: remove 'nil' from type packs
 --- @deprecated 1.2, use `ServerAsync` instead.
 export type ClientToServerAsync<Returns = any, Args... = ...any> = types.ServerAsync<Args..., (Returns, nil)>
-
 --- @deprecated 1.2, use `ClientAsync` instead.
 export type ServerToClientAsync<Returns = any, Args... = ...any> = types.ClientAsync<Args..., (Returns, nil)>
 

--- a/src/middleware/throttleMiddleware.spec.lua
+++ b/src/middleware/throttleMiddleware.spec.lua
@@ -24,7 +24,7 @@ return function()
 	end
 
 	describe("event throttle", function()
-		local remotes, remote: types.ServerToClient, instance: RemoteEvent
+		local remotes, remote: types.ClientToServer, instance: RemoteEvent
 
 		local function create(options: throttleMiddleware.ThrottleMiddlewareOptions)
 			remotes = createRemotes({ remote = builder.remote() }, throttleMiddleware(options))
@@ -144,7 +144,7 @@ return function()
 	end)
 
 	describe("async throttle", function()
-		local remotes, remote: types.ServerToClientAsync, instance: RemoteFunction
+		local remotes, remote: types.ServerAsync, instance: RemoteFunction
 
 		local function create(options: throttleMiddleware.ThrottleMiddlewareOptions)
 			remotes = createRemotes({ remote = builder.remote().returns() }, throttleMiddleware(options))

--- a/src/server/createAsyncRemote.lua
+++ b/src/server/createAsyncRemote.lua
@@ -11,7 +11,7 @@ local function createAsyncRemote(name: string, builder: types.RemoteBuilder): ty
 	local instance = instances.createRemoteFunction(name)
 	local connected = true
 
-	local function handler(...): any
+	local function handler(...): ...any
 		return
 	end
 
@@ -43,7 +43,7 @@ local function createAsyncRemote(name: string, builder: types.RemoteBuilder): ty
 		end
 	end
 
-	local asyncRemoteNotCallable: types.AsyncRemoteNotCallable = {
+	local api: types.AsyncRemoteApi = {
 		name = name,
 		type = "function" :: "function",
 		onRequest = onRequest,
@@ -51,7 +51,7 @@ local function createAsyncRemote(name: string, builder: types.RemoteBuilder): ty
 		destroy = destroy,
 	}
 
-	local asyncRemote = setmetatable(asyncRemoteNotCallable, {
+	local asyncRemote = setmetatable(api, {
 		__call = request,
 	}) :: types.AsyncRemote
 

--- a/src/types.lua
+++ b/src/types.lua
@@ -1,18 +1,12 @@
 local Promise = require(script.Parent.Promise)
 
-export type Promise<T> = Promise.Promise<T>
+type Cleanup = () -> ()
 
-export type PromiseConstructor = Promise.PromiseConstructor
+type Promise<T...> = Promise.Promise<T...>
 
 export type Validator = any
 
-export type Cleanup = () -> ()
-
 export type Middleware = (next: (...any) -> ...any, remote: AnyRemote) -> (...any) -> ...any
-
-export type MiddlewareContext = {
-	player: Player,
-}
 
 export type RemoteBuilder = {
 	type: RemoteType,
@@ -42,6 +36,14 @@ export type AnyRemote = Remote | AsyncRemote
 
 export type Remote<Args... = ...any> = ClientToServer<Args...> & ServerToClient<Args...>
 
+export type Remotes<Map = RemoteMap> = Map & {
+	destroy: (self: Remotes<Map>) -> (),
+}
+
+export type RemoteMap = {
+	[string]: AnyRemote | RemoteMap,
+}
+
 export type ClientToServer<Args... = ...any> = {
 	name: string,
 	type: "event",
@@ -61,50 +63,42 @@ export type ServerToClient<Args... = ...any> = {
 	destroy: (self: ServerToClient<Args...>) -> (),
 }
 
-export type AsyncRemote<Returns = any, Args... = ...any> =
-	ClientToServerAsync<Returns, Args...>
-	& ServerToClientAsync<Returns, Args...>
+export type AsyncRemote<Args... = ...any, Returns... = ...any> =
+	ServerAsync<Args..., Returns...>
+	& ClientAsync<Args..., Returns...>
 
-export type ServerToClientAsync<Returns = any, Args... = ...any> =
-	((player: Player, Args...) -> Promise<Returns>)
-	& ServerToClientAsyncNotCallable<Returns, Args...>
+export type ServerAsync<Args... = ...any, Returns... = ...any> =
+	((Args...) -> Promise<Returns...>)
+	& ServerAsyncApi<Args..., Returns...>
 
-export type ClientToServerAsync<Returns = any, Args... = ...any> =
-	((Args...) -> Promise<Returns>)
-	& ClientToServerAsyncNotCallable<Returns, Args...>
+export type ClientAsync<Args... = ...any, Returns... = ...any> =
+	((player: Player, Args...) -> Promise<Returns...>)
+	& ClientAsyncApi<Args..., Returns...>
 
-export type AsyncRemoteNotCallable<Returns = any, Args... = ...any> =
-	ServerToClientAsyncNotCallable<Returns, Args...>
-	& ClientToServerAsyncNotCallable<Returns, Args...>
+export type AsyncRemoteApi<Args... = ...any, Returns... = ...any> =
+	ServerAsyncApi<Args..., Returns...>
+	& ClientAsyncApi<Args..., Returns...>
 
-type ServerToClientAsyncNotCallable<Returns = any, Args... = ...any> = {
+export type ServerAsyncApi<Args..., Returns...> = {
 	name: string,
 	type: "function",
 	onRequest: (
-		self: ServerToClientAsyncNotCallable<Returns, Args...>,
-		callback: (Args...) -> Returns | Promise<Returns>
+		self: ServerAsyncApi<Args..., Returns...>,
+		callback: ((player: Player, Args...) -> Returns...) | (player: Player, Args...) -> Promise<Returns...>
 	) -> (),
-	request: (self: ServerToClientAsyncNotCallable<Returns, Args...>, player: Player, Args...) -> Promise<Returns>,
-	destroy: (self: ServerToClientAsyncNotCallable<Returns, Args...>) -> (),
+	request: (self: ServerAsyncApi<Args..., Returns...>, Args...) -> Promise<Returns...>,
+	destroy: (self: ServerAsyncApi<Args..., Returns...>) -> (),
 }
 
-type ClientToServerAsyncNotCallable<Returns = any, Args... = ...any> = {
+export type ClientAsyncApi<Args..., Returns...> = {
 	name: string,
 	type: "function",
 	onRequest: (
-		self: ClientToServerAsyncNotCallable<Returns, Args...>,
-		callback: (player: Player, Args...) -> Returns | Promise<Returns>
+		self: ClientAsyncApi<Args..., Returns...>,
+		callback: ((Args...) -> Returns...) | (Args...) -> Promise<Returns...>
 	) -> (),
-	request: (self: ClientToServerAsyncNotCallable<Returns, Args...>, Args...) -> Promise<Returns>,
-	destroy: (self: ClientToServerAsyncNotCallable<Returns, Args...>) -> (),
-}
-
-export type Remotes<Map = RemoteMap> = Map & {
-	destroy: (self: Remotes<Map>) -> (),
-}
-
-export type RemoteMap = {
-	[string]: AnyRemote | RemoteMap,
+	request: (self: ClientAsyncApi<Args..., Returns...>, Args...) -> Promise<Returns...>,
+	destroy: (self: ClientAsyncApi<Args..., Returns...>) -> (),
 }
 
 return nil


### PR DESCRIPTION
This PR adds the `ClientAsync` and `ServerAsync` types for declaring an async remote that has more than one return value.

## What's New

- **(Luau)** 🔢 Use tuples for async remote return types 2d25d4ff5d8411e61d8d9dee30e9f1e8f1e36ec8