### PR TITLE
feat: add `test` remote api

### DIFF
--- a/src/client/createAsyncRemote.spec.lua
+++ b/src/client/createAsyncRemote.spec.lua
@@ -172,4 +172,23 @@ return function()
 
 		expect(asyncRemote("test", 1):expect()).to.equal("result")
 	end)
+
+	it("should invoke the test handler", function()
+		local arg1, arg2
+
+		asyncRemote.test:handleRequest(function(...)
+			arg1, arg2 = ...
+			return "result"
+		end)
+
+		expect(asyncRemote:request("test", 1):expect()).to.equal("result")
+		expect(arg1).to.equal("test")
+		expect(arg2).to.equal(1)
+
+		asyncRemote.test:disconnectAll()
+
+		expect(function()
+			asyncRemote:request("test", 1):expect()
+		end).to.throw()
+	end)
 end

--- a/src/client/createRemote.lua
+++ b/src/client/createRemote.lua
@@ -1,9 +1,11 @@
 local types = require(script.Parent.Parent.types)
 local compose = require(script.Parent.Parent.utils.compose)
 local instances = require(script.Parent.Parent.utils.instances)
+local testRemote = require(script.Parent.Parent.utils.testRemote)
 
 local function createRemote(name: string, builder: types.RemoteBuilder): types.Remote
 	local connection: RBXScriptConnection?
+	local test = testRemote.createTestRemote()
 	local connected = true
 
 	local listeners: { (...any) -> () } = {}
@@ -32,6 +34,7 @@ local function createRemote(name: string, builder: types.RemoteBuilder): types.R
 
 		instances.promiseRemoteEvent(name):andThen(function(instance)
 			instance:FireServer(table.unpack(arguments, 1, arguments.n))
+			test:_fire(table.unpack(arguments, 1, arguments.n))
 		end, function(error): ()
 			warn(`Failed to fire remote '{name}': {error}`)
 		end)
@@ -55,6 +58,7 @@ local function createRemote(name: string, builder: types.RemoteBuilder): types.R
 	local remote: types.Remote = {
 		name = name,
 		type = "event" :: "event",
+		test = test,
 		connect = connect,
 		fire = fire,
 		fireAll = noop,

--- a/src/client/createRemote.spec.lua
+++ b/src/client/createRemote.spec.lua
@@ -112,4 +112,30 @@ return function()
 		expect(arg1).to.equal("intercepted")
 		expect(arg2).to.equal(2)
 	end)
+
+	it("should fire the test listeners", function()
+		local test1, test2, arg1, arg2
+
+		remote.test:onFire(function(...)
+			test1, test2 = ...
+		end)
+
+		instance.OnServerEvent:Connect(function(_, ...)
+			arg1, arg2 = ...
+		end)
+
+		remote:fire("test", 1)
+
+		expect(test1).to.equal(arg1)
+		expect(test2).to.equal(arg2)
+
+		test1, test2, arg1, arg2 = nil
+		remote.test:disconnectAll()
+		remote:fire("test", 1)
+
+		expect(test1).to.never.be.ok()
+		expect(test2).to.never.be.ok()
+		expect(arg1).to.equal("test")
+		expect(arg2).to.equal(1)
+	end)
 end

--- a/src/server/createAsyncRemote.spec.lua
+++ b/src/server/createAsyncRemote.spec.lua
@@ -170,4 +170,23 @@ return function()
 
 		expect(asyncRemote(player, "test", 1):expect()).to.equal("result")
 	end)
+
+	it("should invoke the test handler", function()
+		local arg1, arg2
+
+		asyncRemote.test:handleRequest(function(...)
+			arg1, arg2 = ...
+			return "result"
+		end)
+
+		expect(asyncRemote:request(player, "test", 1):expect()).to.equal("result")
+		expect(arg1).to.equal("test")
+		expect(arg2).to.equal(1)
+
+		asyncRemote.test:disconnectAll()
+
+		expect(function()
+			asyncRemote:request("test", 1):expect()
+		end).to.throw()
+	end)
 end

--- a/src/server/createRemote.lua
+++ b/src/server/createRemote.lua
@@ -3,9 +3,11 @@ local Players = game:GetService("Players")
 local types = require(script.Parent.Parent.types)
 local compose = require(script.Parent.Parent.utils.compose)
 local instances = require(script.Parent.Parent.utils.instances)
+local testRemote = require(script.Parent.Parent.utils.testRemote)
 
 local function createRemote(name: string, builder: types.RemoteBuilder): types.Remote
 	local instance = instances.createRemoteEvent(name)
+	local test = testRemote.createTestRemote()
 	local connected = true
 
 	local listeners: { (...any) -> () } = {}
@@ -26,11 +28,13 @@ local function createRemote(name: string, builder: types.RemoteBuilder): types.R
 	local function fire(self: any, player, ...)
 		assert(connected, `Cannot fire destroyed event remote '{name}'`)
 		instance:FireClient(player, ...)
+		test:_fire(...)
 	end
 
 	local function fireAll(self, ...)
 		assert(connected, `Cannot fire destroyed event remote '{name}'`)
 		instance:FireAllClients(...)
+		test:_fire(...)
 	end
 
 	local function fireAllExcept(self, exception, ...)
@@ -40,6 +44,7 @@ local function createRemote(name: string, builder: types.RemoteBuilder): types.R
 				instance:FireClient(player, ...)
 			end
 		end
+		test:_fire(...)
 	end
 
 	local function firePlayers(self, players, ...)
@@ -47,6 +52,7 @@ local function createRemote(name: string, builder: types.RemoteBuilder): types.R
 		for _, player in players do
 			instance:FireClient(player, ...)
 		end
+		test:_fire(...)
 	end
 
 	local function destroy()
@@ -65,6 +71,7 @@ local function createRemote(name: string, builder: types.RemoteBuilder): types.R
 	local remote: types.Remote = {
 		name = name,
 		type = "event" :: "event",
+		test = test,
 		connect = connect,
 		fire = fire,
 		fireAll = fireAll,

--- a/src/server/createRemote.spec.lua
+++ b/src/server/createRemote.spec.lua
@@ -109,4 +109,30 @@ return function()
 		expect(arg1).to.equal("intercepted")
 		expect(arg2).to.equal(2)
 	end)
+
+	it("should fire the test listeners", function()
+		local test1, test2, arg1, arg2
+
+		remote.test:onFire(function(...)
+			test1, test2 = ...
+		end)
+
+		instance.OnClientEvent:Connect(function(...)
+			arg1, arg2 = ...
+		end)
+
+		remote:fireAll("test", 1)
+
+		expect(test1).to.equal(arg1)
+		expect(test2).to.equal(arg2)
+
+		test1, test2, arg1, arg2 = nil
+		remote.test:disconnectAll()
+		remote:fireAll("test", 1)
+
+		expect(test1).to.never.be.ok()
+		expect(test2).to.never.be.ok()
+		expect(arg1).to.equal("test")
+		expect(arg2).to.equal(1)
+	end)
 end

--- a/src/types.lua
+++ b/src/types.lua
@@ -47,6 +47,7 @@ export type RemoteMap = {
 export type ClientToServer<Args... = ...any> = {
 	name: string,
 	type: "event",
+	test: TestRemote<Args...>,
 	connect: (self: ClientToServer<Args...>, callback: (player: Player, Args...) -> ()) -> Cleanup,
 	fire: (self: ClientToServer<Args...>, Args...) -> (),
 	destroy: (self: ClientToServer<Args...>) -> (),
@@ -55,6 +56,7 @@ export type ClientToServer<Args... = ...any> = {
 export type ServerToClient<Args... = ...any> = {
 	name: string,
 	type: "event",
+	test: TestRemote<Args...>,
 	connect: (self: ServerToClient<Args...>, callback: (Args...) -> ()) -> Cleanup,
 	fire: (self: ServerToClient<Args...>, player: Player, Args...) -> (),
 	firePlayers: (self: ServerToClient<Args...>, players: { Player }, Args...) -> (),
@@ -82,6 +84,7 @@ export type AsyncRemoteApi<Args... = ...any, Returns... = ...any> =
 export type ServerAsyncApi<Args..., Returns...> = {
 	name: string,
 	type: "function",
+	test: TestAsyncRemote<Args..., Returns...>,
 	onRequest: (
 		self: ServerAsyncApi<Args..., Returns...>,
 		callback: ((player: Player, Args...) -> Returns...) | (player: Player, Args...) -> Promise<Returns...>
@@ -93,12 +96,29 @@ export type ServerAsyncApi<Args..., Returns...> = {
 export type ClientAsyncApi<Args..., Returns...> = {
 	name: string,
 	type: "function",
+	test: TestAsyncRemote<Args..., Returns...>,
 	onRequest: (
 		self: ClientAsyncApi<Args..., Returns...>,
 		callback: ((Args...) -> Returns...) | (Args...) -> Promise<Returns...>
 	) -> (),
 	request: (self: ClientAsyncApi<Args..., Returns...>, Args...) -> Promise<Returns...>,
 	destroy: (self: ClientAsyncApi<Args..., Returns...>) -> (),
+}
+
+export type TestRemote<Args... = ...any> = {
+	_fire: (self: TestRemote<Args...>, Args...) -> (),
+	onFire: (self: TestRemote<Args...>, callback: (Args...) -> ()) -> Cleanup,
+	disconnectAll: (self: TestRemote<Args...>) -> (),
+}
+
+export type TestAsyncRemote<Args... = ...any, Returns... = ...any> = {
+	_request: (self: TestAsyncRemote<Args..., Returns...>, Args...) -> Returns...,
+	handleRequest: (
+		self: TestAsyncRemote<Args..., Returns...>,
+		callback: ((Args...) -> Returns...) | (Args...) -> Promise<Returns...>
+	) -> (),
+	hasRequestHandler: (self: TestAsyncRemote<Args..., Returns...>) -> boolean,
+	disconnectAll: (self: TestAsyncRemote<Args..., Returns...>) -> (),
 }
 
 return nil

--- a/src/utils/testRemote.lua
+++ b/src/utils/testRemote.lua
@@ -1,0 +1,70 @@
+local types = require(script.Parent.Parent.types)
+
+local function createTestRemote(): types.TestRemote
+	local listeners: { (...any) -> () } = {}
+	local nextListenerId = 0
+
+	local function fire(self, ...)
+		for _, listener in listeners do
+			listener(...)
+		end
+	end
+
+	local function onFire(self, listener)
+		local id = nextListenerId
+		nextListenerId += 1
+		listeners[id] = listener
+
+		return function()
+			listeners[id] = nil
+		end
+	end
+
+	local function disconnectAll(self)
+		table.clear(listeners)
+	end
+
+	local testRemote: types.TestRemote = {
+		_fire = fire,
+		onFire = onFire,
+		disconnectAll = disconnectAll,
+	}
+
+	return testRemote
+end
+
+local function createTestAsyncRemote(): types.TestAsyncRemote
+	local function noop() end
+
+	local handler = noop
+
+	local function request(self, ...)
+		return handler(...)
+	end
+
+	local function handleRequest(self, newHandler)
+		handler = newHandler
+	end
+
+	local function hasRequestHandler(self)
+		return handler ~= noop
+	end
+
+	local function disconnectAll(self)
+		handler = noop
+	end
+
+	local testAsyncRemote: types.TestAsyncRemote = {
+		_request = request,
+		handleRequest = handleRequest,
+		hasRequestHandler = hasRequestHandler,
+		disconnectAll = disconnectAll,
+	}
+
+	return testAsyncRemote
+end
+
+return {
+	createTestRemote = createTestRemote,
+	createTestAsyncRemote = createTestAsyncRemote,
+}


### PR DESCRIPTION
This PR adds the `test` property to remotes, a `TestRemote`/`TestAsyncRemote` object.

This is intended to be used in stories and tests, useful for intercepting outgoing events or returning a mock value.

```ts
remote.test.onFire((value) => {
  received = value;
});

remote.fire("value");

remote.test.disconnectAll();
```

```ts
asyncRemote.test.handleRequest((value) => {
  return value + 1;
});

const two = await asyncRemote.request(1);

asyncRemote.test.disconnectAll();
```

Note that test handlers do not receive a `player` property, regardless of whether it is called on the client or server.