### PR TITLE
fix: avoid omitting first argument in test remote

### DIFF
--- a/examples/lua/src/shared/remotes.lua
+++ b/examples/lua/src/shared/remotes.lua
@@ -3,7 +3,6 @@ local ReplicatedStorage = game:GetService("ReplicatedStorage")
 local Remo = require(ReplicatedStorage.Packages.Remo)
 local t = require(ReplicatedStorage.Packages.t)
 
--- stylua: ignore
 type Remotes = Remo.Remotes<{
 	addTodo: Remo.ClientToServer<string>,
 	removeTodo: Remo.ClientToServer<string>,

--- a/src/createRemotes.spec.lua
+++ b/src/createRemotes.spec.lua
@@ -7,7 +7,6 @@ return function()
 	local builder = require(script.Parent.builder)
 	local mockRemotes = require(script.Parent.utils.mockRemotes)
 
-	-- stylua: ignore
 	local remotes: types.Remotes<{
 		event: types.ClientToServer<string, number>,
 		callback: types.ServerAsync<(string, number), (string)>,

--- a/src/init.lua
+++ b/src/init.lua
@@ -27,11 +27,9 @@ export type AsyncRemote<Args... = ...any, Returns... = ...any> = types.AsyncRemo
 export type ServerAsync<Args... = ...any, Returns... = ...any> = types.ServerAsync<Args..., Returns...>
 export type ClientAsync<Args... = ...any, Returns... = ...any> = types.ClientAsync<Args..., Returns...>
 
--- stylua: ignore
 --- @deprecated 1.2, use `ServerAsync` instead.
 export type ClientToServerAsync<Returns = any, Args... = ...any> = types.ServerAsync<Args..., (Returns)>
 
--- stylua: ignore
 --- @deprecated 1.2, use `ClientAsync` instead.
 export type ServerToClientAsync<Returns = any, Args... = ...any> = types.ClientAsync<Args..., (Returns)>
 

--- a/src/server/createAsyncRemote.lua
+++ b/src/server/createAsyncRemote.lua
@@ -27,7 +27,7 @@ local function createAsyncRemote(name: string, builder: types.RemoteBuilder): ty
 
 		return Promise.try(function(...)
 			local response = if test:hasRequestHandler()
-				then table.pack(test:_request(...)) :: never
+				then table.pack(test:_request(player, ...)) :: never
 				else table.pack(instance:InvokeClient(player, ...))
 
 			for index, validator in builder.metadata.returns do

--- a/src/server/createAsyncRemote.spec.lua
+++ b/src/server/createAsyncRemote.spec.lua
@@ -179,7 +179,7 @@ return function()
 			return "result"
 		end)
 
-		expect(asyncRemote:request(player, "test", 1):expect()).to.equal("result")
+		expect(asyncRemote:request("test", 1):expect()).to.equal("result")
 		expect(arg1).to.equal("test")
 		expect(arg2).to.equal(1)
 

--- a/src/server/createRemote.lua
+++ b/src/server/createRemote.lua
@@ -28,7 +28,7 @@ local function createRemote(name: string, builder: types.RemoteBuilder): types.R
 	local function fire(self: any, player, ...)
 		assert(connected, `Cannot fire destroyed event remote '{name}'`)
 		instance:FireClient(player, ...)
-		test:_fire(...)
+		test:_fire(player, ...) -- do not risk omitting first argument
 	end
 
 	local function fireAll(self, ...)

--- a/src/utils/testRemote.lua
+++ b/src/utils/testRemote.lua
@@ -1,12 +1,21 @@
 local types = require(script.Parent.Parent.types)
+local getSender = require(script.Parent.Parent.getSender)
+
+local function noop() end
 
 local function createTestRemote(): types.TestRemote
 	local listeners: { (...any) -> () } = {}
 	local nextListenerId = 0
 
-	local function fire(self, ...)
+	local function fire(self, first, ...)
+		local shouldOmitPlayer = getSender(first)
+
 		for _, listener in listeners do
-			listener(...)
+			if shouldOmitPlayer then
+				listener(...)
+			else
+				listener(first, ...)
+			end
 		end
 	end
 
@@ -34,12 +43,10 @@ local function createTestRemote(): types.TestRemote
 end
 
 local function createTestAsyncRemote(): types.TestAsyncRemote
-	local function noop() end
+	local handler: (...any) -> () = noop
 
-	local handler = noop
-
-	local function request(self, ...)
-		return handler(...)
+	local function request(self, first, ...)
+		return if getSender(first) then handler(...) else handler(first, ...)
 	end
 
 	local function handleRequest(self, newHandler)


### PR DESCRIPTION
Omit the first argument to the server test remote's `_fire` and `_request` APIs only if it is a valid Player object.

Fixes an issue where Hoarcekat stories may be seen as a server environment, causing Remo to assume the first argument to a test remote is always a player, and omitting important arguments in the process.