### PR TITLE
Added ignoreUnknownInstances to container/init.meta.json

### DIFF
--- a/src/container/init.meta.json
+++ b/src/container/init.meta.json
@@ -1,3 +1,4 @@
 {
-	"className": "Configuration"
+	"className": "Configuration",
+	"ignoreUnknownInstances": true
 }


### PR DESCRIPTION
Very simple fix for Rojo nuking remo's generated RemoteEvents, when syncing during play (while using a hot-reloading setup, for example).