### PR TITLE
fix: check for `include` folder

### DIFF
--- a/src/Promise.lua
+++ b/src/Promise.lua
@@ -1,6 +1,7 @@
 local ReplicatedStorage = game:GetService("ReplicatedStorage")
 
 local include = script:FindFirstAncestor("rbxts_include")
+	or script:FindFirstAncestor("include")
 	or ReplicatedStorage:FindFirstChild("rbxts_include")
 	or script.Parent.Parent
 


### PR DESCRIPTION
Fixes a bug when importing Promise from a Roblox-TS model; the folder is called `include` and not `rbxts_include`, so add a check for it