### PR TITLE
feat: add mockPlayer function

### DIFF
--- a/src/getSender.lua
+++ b/src/getSender.lua
@@ -1,7 +1,7 @@
 local constants = require(script.Parent.constants)
 
-local function getSender(player: unknown): Player?
-	if constants.IS_SERVER and typeof(player) == "Instance" and player:IsA("Player") then
+local function getSender(player: any): Player?
+	if constants.IS_SERVER and (typeof(player) == "Instance" and player:IsA("Player")) or player.__unique_player_identifier_do_not_use then
 		return player
 	end
 	return nil

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -75,6 +75,13 @@ declare namespace Remo {
 	 */
 	export function getSender(...args: unknown[]): Player | undefined;
 
+	/**
+	 * Creates a mock player used for testing, only UserId is stored
+	 * currently, but you can pass other values though it may cause
+	 * unexpected behavior
+	 */
+	export function mockPlayer(player: Partial<Player>): Player;
+
 	interface ThrottleMiddlewareOptions {
 		/**
 		 * The number of seconds to wait before the remote can be invoked again.

--- a/src/init.lua
+++ b/src/init.lua
@@ -3,6 +3,7 @@ local types = require(script.types)
 local createRemotes = require(script.createRemotes)
 local builder = require(script.builder)
 local getSender = require(script.getSender)
+local mockPlayer = require(script.mockPlayer)
 local loggerMiddleware = require(script.middleware.loggerMiddleware)
 local throttleMiddleware = require(script.middleware.throttleMiddleware)
 
@@ -40,4 +41,5 @@ return {
 	loggerMiddleware = loggerMiddleware,
 	throttleMiddleware = throttleMiddleware,
 	getSender = getSender,
+	mockPlayer = mockPlayer
 }

--- a/src/mockPlayer.lua
+++ b/src/mockPlayer.lua
@@ -1,0 +1,8 @@
+local function mockPlayer(mock: { UserId: number }): Player
+    return {
+        UserId = mock.UserId,
+        __unique_player_identifier_do_not_use = true
+    } :: any
+end
+
+return mockPlayer

--- a/src/mockPlayer.spec.lua
+++ b/src/mockPlayer.spec.lua
@@ -1,0 +1,8 @@
+local mockPlayer = require(script.Parent.mockPlayer)
+
+return function() 
+    it("should create a mock player", function() 
+        local mock = mockPlayer({ UserId = 1 })
+        expect(mock).to.equal({ UserId = 1, __unique_player_identifier_do_not_use = true })
+    end)
+end


### PR DESCRIPTION
This pull request allows mockPlayer function to be used. It modifies the getSender function to fake detect if the player has the field \_\_unique_player_identifier_do_not_use. Currently only UserId is supported for mocking, other properites aren't implemented.
