### PR TITLE
Fix tuple returns for test remotes

### DIFF
--- a/src/client/createAsyncRemote.luau
+++ b/src/client/createAsyncRemote.luau
@@ -49,7 +49,6 @@ local function createAsyncRemote(name: string, builder: types.RemoteBuilder): ty
 	end
 
 	local invoke = compose(builder.metadata.middleware)(function(...: any): any
-		handler(...)
 		return unwrap(handler(...))
 	end, self)
 

--- a/src/utils/testRemote.luau
+++ b/src/utils/testRemote.luau
@@ -46,7 +46,11 @@ local function createTestAsyncRemote(): types.TestAsyncRemote
 	local handler: (...any) -> () = noop
 
 	local function request(_self, first, ...)
-		return if getSender(first) then handler(...) else handler(first, ...)
+		if getSender(first) then
+            return handler(...)
+        else
+            return handler(first, ...)
+        end
 	end
 
 	local function handleRequest(_self, newHandler)

--- a/src/utils/unwrap.luau
+++ b/src/utils/unwrap.luau
@@ -2,12 +2,12 @@ local Promise = require(script.Parent.Parent.Promise)
 
 type Promise<T> = Promise.Promise<T>
 
-local function unwrap<T>(...: Promise<T> | T): T
-	if Promise.is(...) then
-		return (... :: Promise<T>):expect()
+local function unwrap<T, U...>(promise: T | Promise<T>?, ...: U...): (T, U...)
+	if Promise.is(promise) then
+		return (promise :: Promise<T>):expect()
 	end
 
-	return (...) :: T
+	return promise :: T, ...
 end
 
 return unwrap


### PR DESCRIPTION
The current implementation results in only the first value being returned, for example:

```lua
Remote.DoSomethingAsync.test:handleRequest(function()
    return 1, 2, 3
end)

Remote.DoSomethingAsync():andThen(function(a, b, c)
    print(a, b, c) -- 1 nil nil
end)
```

This PR expands the ternary expression into a full if-else branch such that the full tuple is returned correctly.